### PR TITLE
disabled event logging and onboarding/preferences

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -348,14 +348,14 @@ dependencies {
     androidTestImplementation "android.arch.persistence.room:testing:1.1.1"
     androidTestUtil 'androidx.test:orchestrator:1.4.1'
 
-    // use local files for debug builds to support development
-    debugImplementation files('libs/cronet-debug.aar')
-    debugImplementation files('libs/envoy-debug.aar')
-    debugImplementation files('libs/IEnvoyProxy.aar')
-    // use maven dependencies for release builds to support automation
-    releaseImplementation 'org.greatfire.envoy:cronet:102.0.5005.41'
-    releaseImplementation 'org.greatfire:envoy:102.00.5005.41.4'
-    releaseImplementation 'org.greatfire:IEnvoyProxy:1.2.0'
+    // switch to local files if needed to support development
+    // implementation files('libs/cronet-debug.aar')
+    // implementation files('libs/envoy-debug.aar')
+    // implementation files('libs/IEnvoyProxy.aar')
+    // use maven dependencies to support automation
+    implementation 'org.greatfire.envoy:cronet:102.0.5005.41'
+    implementation 'org.greatfire:envoy:102.00.5005.41.4'
+    implementation 'org.greatfire:IEnvoyProxy:1.2.0'
 }
 
 /*

--- a/app/src/main/java/org/wikipedia/analytics/EventLoggingService.kt
+++ b/app/src/main/java/org/wikipedia/analytics/EventLoggingService.kt
@@ -1,6 +1,7 @@
 package org.wikipedia.analytics
 
 import android.net.Uri
+import android.util.Log
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import okhttp3.Request
@@ -15,6 +16,7 @@ import org.wikipedia.util.log.L
 class EventLoggingService private constructor() {
 
     fun log(event: JSONObject?) {
+        Log.d("ENVOY_LOG", "event logging is currently enabled:" + Prefs.isEventLoggingEnabled + ", log events if necessary")
         if (!Prefs.isEventLoggingEnabled || !WikipediaApp.instance.isOnline) {
             // Do not send events if the user opted out of EventLogging or the device is offline.
             return

--- a/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
+++ b/app/src/main/java/org/wikipedia/analytics/eventplatform/EventPlatformClient.kt
@@ -1,5 +1,6 @@
 package org.wikipedia.analytics.eventplatform
 
+import android.util.Log
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.wikipedia.BuildConfig
 import org.wikipedia.WikipediaApp
@@ -59,10 +60,13 @@ object EventPlatformClient {
      */
     @Synchronized
     fun submit(event: Event) {
+        // TEMP: disable code for now so events are not logged to wikipedia
+        /*
         if (!SamplingController.isInSample(event) || (event is BreadCrumbLogEvent && ReleaseUtil.isProdRelease)) {
             return
         }
         OutputBuffer.schedule(event)
+        */
     }
 
     fun flushCachedEvents() {
@@ -144,6 +148,7 @@ object EventPlatformClient {
          * can contain events of different streams
          */
         private fun send() {
+            Log.d("ENVOY_LOG", "event logging is currently enabled:" + Prefs.isEventLoggingEnabled + ", send events if necessary")
             if (!Prefs.isEventLoggingEnabled) {
                 return
             }

--- a/app/src/main/java/org/wikipedia/dataclient/okhttp/CommonHeaderRequestInterceptor.kt
+++ b/app/src/main/java/org/wikipedia/dataclient/okhttp/CommonHeaderRequestInterceptor.kt
@@ -1,5 +1,6 @@
 package org.wikipedia.dataclient.okhttp
 
+import android.util.Log
 import okhttp3.Interceptor
 import okhttp3.Response
 import org.wikipedia.WikipediaApp
@@ -11,6 +12,7 @@ internal class CommonHeaderRequestInterceptor : Interceptor {
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         val app = WikipediaApp.instance
+        Log.d("ENVOY_LOG", "event logging is currently enabled:" + isEventLoggingEnabled + ", configure necessary headers")
         val builder = chain.request().newBuilder()
                 .header("User-Agent", app.userAgent)
                 .header(if (isEventLoggingEnabled) "X-WMF-UUID" else "DNT",

--- a/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingFragment.kt
+++ b/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingFragment.kt
@@ -42,9 +42,11 @@ class InitialOnboardingFragment : OnboardingFragment(), OnboardingPageView.Callb
     }
 
     override fun onSwitchChange(view: OnboardingPageView, checked: Boolean) {
+        /*
         if (OnboardingPage.of(view.tag as Int) == OnboardingPage.PAGE_USAGE_DATA) {
             Prefs.isEventLoggingEnabled = checked
         }
+        */
     }
 
     override fun onLinkClick(view: OnboardingPageView, url: String) {
@@ -84,9 +86,11 @@ class InitialOnboardingFragment : OnboardingFragment(), OnboardingPageView.Callb
             super.onCreateView(inflater, container, savedInstanceState)
             val position = requireArguments().getInt("position", 0)
             val view = inflater.inflate(OnboardingPage.of(position).layout, container, false) as OnboardingPageView
+            /*
             if (OnboardingPage.PAGE_USAGE_DATA.code() == position) {
                 view.setSwitchChecked(Prefs.isEventLoggingEnabled)
             }
+            */
             view.tag = position
             view.callback = callback
             return view
@@ -106,8 +110,8 @@ class InitialOnboardingFragment : OnboardingFragment(), OnboardingPageView.Callb
     internal enum class OnboardingPage(@LayoutRes val layout: Int) : EnumCode {
         PAGE_WELCOME(R.layout.inflate_initial_onboarding_page_zero),
         PAGE_EXPLORE(R.layout.inflate_initial_onboarding_page_one),
-        PAGE_READING_LISTS(R.layout.inflate_initial_onboarding_page_two),
-        PAGE_USAGE_DATA(R.layout.inflate_initial_onboarding_page_three);
+        PAGE_READING_LISTS(R.layout.inflate_initial_onboarding_page_two);
+        // PAGE_USAGE_DATA(R.layout.inflate_initial_onboarding_page_three);
 
         override fun code(): Int {
             return ordinal

--- a/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingFragment.kt
+++ b/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingFragment.kt
@@ -17,7 +17,7 @@ import org.wikipedia.analytics.LoginFunnel
 import org.wikipedia.login.LoginActivity
 import org.wikipedia.model.EnumCode
 import org.wikipedia.model.EnumCodeMap
-import org.wikipedia.settings.Prefs
+//import org.wikipedia.settings.Prefs
 import org.wikipedia.settings.languages.WikipediaLanguagesActivity
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.UriUtil

--- a/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingFragment.kt
+++ b/app/src/main/java/org/wikipedia/onboarding/InitialOnboardingFragment.kt
@@ -17,7 +17,7 @@ import org.wikipedia.analytics.LoginFunnel
 import org.wikipedia.login.LoginActivity
 import org.wikipedia.model.EnumCode
 import org.wikipedia.model.EnumCodeMap
-//import org.wikipedia.settings.Prefs
+// import org.wikipedia.settings.Prefs
 import org.wikipedia.settings.languages.WikipediaLanguagesActivity
 import org.wikipedia.util.FeedbackUtil
 import org.wikipedia.util.UriUtil

--- a/app/src/main/java/org/wikipedia/settings/Prefs.kt
+++ b/app/src/main/java/org/wikipedia/settings/Prefs.kt
@@ -115,7 +115,9 @@ object Prefs {
         set(multiplier) = PrefsIoUtil.setInt(R.string.preference_key_text_size_multiplier, multiplier)
 
     var isEventLoggingEnabled
-        get() = PrefsIoUtil.getBoolean(R.string.preference_key_eventlogging_opt_in, true)
+        // TEMP: hard code to false for now so events are not logged to wikipedia
+        // get() = PrefsIoUtil.getBoolean(R.string.preference_key_eventlogging_opt_in, true)
+        get() = false
         set(enabled) = PrefsIoUtil.setBoolean(R.string.preference_key_eventlogging_opt_in, enabled)
 
     val announcementsCountryOverride

--- a/app/src/main/java/org/wikipedia/settings/SettingsPreferenceLoader.kt
+++ b/app/src/main/java/org/wikipedia/settings/SettingsPreferenceLoader.kt
@@ -26,12 +26,15 @@ internal class SettingsPreferenceLoader(fragment: PreferenceFragmentCompat) : Ba
             findPreference(R.string.preference_key_sync_reading_lists).isVisible = false
         }
         findPreference(R.string.preference_key_sync_reading_lists).onPreferenceChangeListener = SyncReadingListsListener()
+        // TEMP: disable event logging preference for now so events are not logged to wikipedia
+        /*
         findPreference(R.string.preference_key_eventlogging_opt_in).onPreferenceChangeListener = Preference.OnPreferenceChangeListener { preference: Preference, newValue: Any ->
             if (!(newValue as Boolean)) {
                 Prefs.appInstallId = null
             }
             true
         }
+        */
         loadPreferences(R.xml.preferences_about)
         updateLanguagePrefSummary()
         findPreference(R.string.preference_key_language).onPreferenceClickListener = Preference.OnPreferenceClickListener {

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -59,11 +59,11 @@
             android:title="@string/preference_title_prefer_offline_content"
             android:summary="@string/preference_summary_prefer_offline_content" />
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/preferences_privacy_settings_heading">
+    <!--PreferenceCategory android:title="@string/preferences_privacy_settings_heading">
         <org.wikipedia.settings.SwitchPreferenceMultiLine
             android:key="@string/preference_key_eventlogging_opt_in"
             android:defaultValue="true"
             android:title="@string/preference_title_eventlogging_opt_in"
             android:summary="@string/preference_summary_eventlogging_opt_in" />
-    </PreferenceCategory>
+    </PreferenceCategory-->
 </PreferenceScreen>


### PR DESCRIPTION
Disabled event logging and related onboarding/preferences since it currently sends events to the wikipedia backend.  Some logging was added to help to verify that events are no longer logged.  Code has been commented out because it may be useful to replace it with our own event logging.