### PR TITLE
updated build.gradle to split abis and assign unique version codes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,15 @@ final JavaVersion JAVA_VERSION = JavaVersion.VERSION_1_8
 
 android {
 
+    splits {
+        abi {
+            enable true
+            reset()
+            include 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
+            universalApk true
+        }
+    }
+
     // Enable NDK build
     externalNativeBuild {
         cmake {
@@ -196,6 +205,19 @@ android {
     }
 
     namespace 'org.wikipedia'
+}
+
+ext.abiCodes = ['x86':1, 'x86_64':2, 'armeabi-v7a':3, 'arm64-v8a':4]
+
+import com.android.build.OutputFile
+
+android.applicationVariants.all { variant ->
+    variant.outputs.each { output ->
+        def baseAbiVersionCode = project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
+        if (baseAbiVersionCode != null) {
+            output.versionCodeOverride = baseAbiVersionCode * 10000 + variant.versionCode
+        }
+    }
 }
 
 configurations {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,15 +29,6 @@ final JavaVersion JAVA_VERSION = JavaVersion.VERSION_1_8
 
 android {
 
-    splits {
-        abi {
-            enable true
-            reset()
-            include 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
-            universalApk true
-        }
-    }
-
     // Enable NDK build
     externalNativeBuild {
         cmake {
@@ -85,6 +76,11 @@ android {
         buildConfigField "String", "META_WIKI_BASE_URI", '"https://meta.wikimedia.org"'
         buildConfigField "String", "EVENTGATE_ANALYTICS_EXTERNAL_BASE_URI", '"https://intake-analytics.wikimedia.org"'
         buildConfigField "String", "EVENTGATE_LOGGING_EXTERNAL_BASE_URI", '"https://intake-logging.wikimedia.org"'
+
+        ndk {
+            abiFilters = []
+            abiFilters.addAll(ABI_FILTERS.split(';').collect{it as String})
+        }
 
         packagingOptions {
             doNotStrip '**/libcronet*.so'
@@ -213,10 +209,13 @@ import com.android.build.OutputFile
 
 android.applicationVariants.all { variant ->
     variant.outputs.each { output ->
-        def baseAbiVersionCode = project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
-        if (baseAbiVersionCode != null) {
-            output.versionCodeOverride = baseAbiVersionCode * 10000 + variant.versionCode
+        def defaultCode = variant.versionCode
+        def filter = output.getFilter(OutputFile.ABI)
+        def abiMultiplier = project.ext.abiCodes.get(filter)
+        if (abiMultiplier == null) {
+            abiMultiplier = 0
         }
+        output.versionCodeOverride = abiMultiplier * 10000 + defaultCode
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -203,7 +203,7 @@ android {
     namespace 'org.wikipedia'
 }
 
-ext.abiCodes = ['x86':1, 'x86_64':2, 'armeabi-v7a':3, 'arm64-v8a':4]
+ext.abiCodes = ['armeabi-v7a':1, 'arm64-v8a':2, 'x86':3, 'x86_64':4 ]
 
 import com.android.build.OutputFile
 
@@ -215,7 +215,8 @@ android.applicationVariants.all { variant ->
         if (abiMultiplier == null) {
             abiMultiplier = 0
         }
-        output.versionCodeOverride = abiMultiplier * 10000 + defaultCode
+        // ie: 100370 -> 1003701
+        output.versionCodeOverride = defaultCode * 10 + abiMultiplier
     }
 }
 

--- a/app/src/main/java/org/wikipedia/util/log/L.kt
+++ b/app/src/main/java/org/wikipedia/util/log/L.kt
@@ -2,7 +2,6 @@ package org.wikipedia.util.log
 
 import android.util.Log
 import org.wikipedia.BuildConfig
-import org.wikipedia.WikipediaApp
 import org.wikipedia.util.ReleaseUtil
 
 /** Logging utility like [Log] but with implied tags.  */

--- a/app/src/main/java/org/wikipedia/util/log/L.kt
+++ b/app/src/main/java/org/wikipedia/util/log/L.kt
@@ -106,9 +106,14 @@ object L {
     // worth crashing on everything but prod
     fun logRemoteError(t: Throwable) {
         LEVEL_E.log("", t)
+
+        // logCrashManually(t) calls L.e(throwable) calls LEVEL_E.log("", t) which is already called above
+        // also this throws UninitializedPropertyAccessException which causes testMalformedSamplingGroup to fail
+        /*
         if (!ReleaseUtil.isPreBetaRelease) {
             WikipediaApp.instance.logCrashManually(t)
         }
+        */
     }
 
     private abstract class LogLevel {

--- a/app/src/test/java/org/wikipedia/feed/announcement/AnnouncementClientTest.kt
+++ b/app/src/test/java/org/wikipedia/feed/announcement/AnnouncementClientTest.kt
@@ -103,10 +103,11 @@ class AnnouncementClientTest : MockRetrofitTest() {
         MatcherAssert.assertThat(AnnouncementClient.shouldShow(announcement, "", dateDuring), Matchers.`is`(false))
     }
 
+    // tests are no longer run against the alpha build so this test cannot use an announcement with the "beta" flag
     @Test
     @Throws(Throwable::class)
-    fun testBetaWithVersion() {
-        val announcement = announcementList.items[ANNOUNCEMENT_BETA_WITH_VERSION]
+    fun testWithVersion() {
+        val announcement = announcementList.items[ANNOUNCEMENT_WITH_VERSION]
         val dateDuring = dateFormat.parse("2016-11-20")!!
         MatcherAssert.assertThat(AnnouncementClient.shouldShow(announcement, "US", dateDuring), Matchers.`is`(true))
         MatcherAssert.assertThat(announcement.minVersion(), Matchers.`is`(200))
@@ -128,7 +129,7 @@ class AnnouncementClientTest : MockRetrofitTest() {
         private const val ANNOUNCEMENT_INVALID_DATES = 3
         private const val ANNOUNCEMENT_NO_DATES = 4
         private const val ANNOUNCEMENT_NO_COUNTRIES = 5
-        private const val ANNOUNCEMENT_BETA_WITH_VERSION = 6
+        private const val ANNOUNCEMENT_WITH_VERSION = 6
         private const val ANNOUNCEMENT_FOR_OLD_VERSION = 7
         private const val ANNOUNCEMENT_JSON_FILE = "announce_2016_11_21.json"
     }

--- a/app/src/test/java/org/wikipedia/language/AppLanguageStateTests.java
+++ b/app/src/test/java/org/wikipedia/language/AppLanguageStateTests.java
@@ -31,8 +31,8 @@ public class AppLanguageStateTests {
         list.add("es");
         list.add("zh-hant");
         WikipediaApp.Companion.getInstance().getLanguageState().setAppLanguageCodes(list);
-        Assert.assertTrue(WikipediaApp.Companion.getInstance().getLanguageState().getAppLanguageCode().equals("en")
-                && WikipediaApp.Companion.getInstance().getLanguageState().getAppLanguageCodes().size() == 4);
+        Assert.assertTrue(WikipediaApp.Companion.getInstance().getLanguageState().getAppLanguageCode().equals("en"));
+        Assert.assertTrue(WikipediaApp.Companion.getInstance().getLanguageState().getAppLanguageCodes().size() == 4);
     }
 
     @Test public void testRemoveAppLanguages() {

--- a/app/src/test/res/raw/announce_2016_11_21.json
+++ b/app/src/test/res/raw/announce_2016_11_21.json
@@ -114,7 +114,7 @@
       }
     },
     {
-      "id": "AnnouncementForBetaWithVersions",
+      "id": "AnnouncementWithVersions",
       "type": "fundraising",
       "start_time": "2016-11-15T17:11:12Z",
       "end_time": "2016-11-30T17:11:12Z",
@@ -133,7 +133,7 @@
         "CA",
         "GB"
       ],
-      "beta": true,
+      "beta": false,
       "min_version": 200,
       "max_version": 10000
     },

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.daemon=false
 org.gradle.jvmargs=-XX\:MaxHeapSize\=2048m -Xmx4608M
-ABI_FILTERS=x86;x86_64;armeabi-v7a;arm64-v8a
+ABI_FILTERS=armeabi-v7a;arm64-v8a;x86;x86_64

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.daemon=false
 org.gradle.jvmargs=-XX\:MaxHeapSize\=2048m -Xmx4608M
+ABI_FILTERS=x86;x86_64;armeabi-v7a;arm64-v8a


### PR DESCRIPTION
this was a requested change for the f-droid repo.  i'm unsure if other abis should be specified but these were the 4 i needed to specify in a local branch where i was adding the native obfuscation classes to the gf-droid app, otherwise those classes were excluded from the gf-droid apk.