### PR TITLE
streamline envoy status monitoring and analytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,9 +54,9 @@ android {
         targetSdkVersion 33
         // current: targetSdkVersion 31
         // TODO: update versionName with each release
-        versionName "4.01"
+        versionName "4.02"
         // TODO: update versionCode with each PR
-        versionCode 100401
+        versionCode 100402
         testApplicationId 'org.greatfire.wikiunblocked.test'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -358,7 +358,7 @@ dependencies {
     // implementation files('libs/IEnvoyProxy.aar')
     // use maven dependencies to support automation
     implementation 'org.greatfire.envoy:cronet:102.0.5005.195-4'
-    implementation 'org.greatfire:envoy:102.0.5005.195.2'
+    implementation 'org.greatfire:envoy:102.0.5005.195.4'
     implementation 'org.greatfire:IEnvoyProxy:1.3.1'
 }
 


### PR DESCRIPTION
These changes are dependent on https://github.com/greatfire/envoy/pull/60

The goal of these changes is to integrate the streamlined status broadcasts from the linked Envoy pr.  Instead of logging the urls that are returned and comparing them to the list that was submitted we can now watch for a broadcast that indicates validation has stopped.

There are several additional changes:
 - added analytics to report the cause of failure
 - removed logged secrets