### PR TITLE
added dialog to improve user interaction with failed states

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -358,7 +358,7 @@ dependencies {
     // implementation files('libs/IEnvoyProxy.aar')
     // use maven dependencies to support automation
     implementation 'org.greatfire.envoy:cronet:107.0.5304.150-1'
-    implementation 'org.greatfire:envoy:107.0.5304.150.3'
+    implementation 'org.greatfire:envoy:107.0.5304.150.4'
     implementation 'org.greatfire:IEnvoyProxy:1.4.2'
 }
 

--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -77,7 +77,15 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
         override fun onClick(p0: DialogInterface?, p1: Int) {
             Log.d(TAG, "retry envoy from dialog")
             checkAndInitEnvoy()
-            retryDialog?.dismiss()
+            retryDialog?.cancel()
+            retryDialog = null
+        }
+    }
+    private val cancelListener: DialogInterface.OnClickListener = object : DialogInterface.OnClickListener {
+        override fun onClick(p0: DialogInterface?, p1: Int) {
+            Log.d(TAG, "cancel dialog")
+            retryDialog?.cancel()
+            retryDialog = null
         }
     }
 
@@ -290,21 +298,29 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
                             Log.w(TAG, "envoy failed, but no urls were submitted")
                         } else if (cause.equals(ENVOY_ENDED_FAILED) || cause.equals(ENVOY_ENDED_BLOCKED)) {
                             Log.w(TAG, "envoy failed, all urls failed or were previously blocked")
-                            retryDialog = AlertDialog.Builder(this@MainActivity)
-                                .setTitle(R.string.failure_dialog_title)
-                                .setMessage(R.string.failure_dialog_content)
-                                .setNegativeButton(R.string.failure_dialog_button_close, null)
-                                .create()
-                            retryDialog?.show()
+                            if (retryDialog != null) {
+                                Log.w(TAG, "dialog already awaiting response")
+                            } else {
+                                retryDialog = AlertDialog.Builder(this@MainActivity)
+                                    .setTitle(R.string.failure_dialog_title)
+                                    .setMessage(R.string.failure_dialog_content)
+                                    .setNegativeButton(R.string.failure_dialog_button_close, cancelListener)
+                                    .create()
+                                retryDialog?.show()
+                            }
                         } else if (cause.equals(ENVOY_ENDED_TIMEOUT)) {
                             Log.w(TAG, "envoy failed, but not all urls were tested")
-                            retryDialog = AlertDialog.Builder(this@MainActivity)
-                                .setTitle(R.string.retry_dialog_title)
-                                .setMessage(R.string.retry_dialog_content)
-                                .setPositiveButton(R.string.retry_dialog_button_retry, retryListener)
-                                .setNegativeButton(R.string.retry_dialog_button_close, null)
-                                .create()
-                            retryDialog?.show()
+                            if (retryDialog != null) {
+                                Log.w(TAG, "dialog already awaiting response")
+                            } else {
+                                retryDialog = AlertDialog.Builder(this@MainActivity)
+                                    .setTitle(R.string.retry_dialog_title)
+                                    .setMessage(R.string.retry_dialog_content)
+                                    .setPositiveButton(R.string.retry_dialog_button_retry, retryListener)
+                                    .setNegativeButton(R.string.retry_dialog_button_close, cancelListener)
+                                    .create()
+                                retryDialog?.show()
+                            }
                         } else {
                             // ENVOY_ENDED_UNKNOWN or other cause
                             Log.w(TAG, "envoy failed, cause unclear")

--- a/app/src/main/java/org/wikipedia/main/MainActivity.kt
+++ b/app/src/main/java/org/wikipedia/main/MainActivity.kt
@@ -1,13 +1,11 @@
 package org.wikipedia.main
 
-import android.content.BroadcastReceiver
-import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
+import android.content.*
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
@@ -73,6 +71,15 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
 
     private val validServices = mutableListOf<String>()
     private val invalidServices = mutableListOf<String>()
+
+    private var retryDialog: AlertDialog? = null
+    private val retryListener: DialogInterface.OnClickListener = object : DialogInterface.OnClickListener {
+        override fun onClick(p0: DialogInterface?, p1: Int) {
+            Log.d(TAG, "retry envoy from dialog")
+            checkAndInitEnvoy()
+            retryDialog?.dismiss()
+        }
+    }
 
     // this receiver should be triggered by a success or failure broadcast from the
     // NetworkIntentService (indicating whether submitted urls were valid or invalid)
@@ -250,6 +257,8 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
                 } else if (intent.action == ENVOY_BROADCAST_VALIDATION_ENDED) {
                     Log.e(TAG, "received an envoy validation ended broadcast")
 
+                    waitingForEnvoy = false
+
                     val validationMs = intent.getLongExtra(ENVOY_DATA_VALIDATION_MS, 0L)
                     if (validationMs <= 0L) {
                         Log.e(TAG, "received an envoy validation ended broadcast with an invalid duration")
@@ -273,9 +282,34 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
                         val bundle = Bundle()
                         bundle.putString(EVENT_PARAM_VALIDATION_ENDED_CAUSE, cause)
                         eventHandler?.logEvent(EVENT_TAG_VALIDATION_ENDED, bundle)
-                    }
 
-                    waitingForEnvoy = false
+                        // display dialog to allow user to retry if possible
+                        if (envoyUnused == true) {
+                            Log.w(TAG, "envoy failed, but direct connection worked")
+                        } else if (cause.equals(ENVOY_ENDED_EMPTY)) {
+                            Log.w(TAG, "envoy failed, but no urls were submitted")
+                        } else if (cause.equals(ENVOY_ENDED_FAILED) || cause.equals(ENVOY_ENDED_BLOCKED)) {
+                            Log.w(TAG, "envoy failed, all urls failed or were previously blocked")
+                            retryDialog = AlertDialog.Builder(this@MainActivity)
+                                .setTitle(R.string.failure_dialog_title)
+                                .setMessage(R.string.failure_dialog_content)
+                                .setNegativeButton(R.string.failure_dialog_button_close, null)
+                                .create()
+                            retryDialog?.show()
+                        } else if (cause.equals(ENVOY_ENDED_TIMEOUT)) {
+                            Log.w(TAG, "envoy failed, but not all urls were tested")
+                            retryDialog = AlertDialog.Builder(this@MainActivity)
+                                .setTitle(R.string.retry_dialog_title)
+                                .setMessage(R.string.retry_dialog_content)
+                                .setPositiveButton(R.string.retry_dialog_button_retry, retryListener)
+                                .setNegativeButton(R.string.retry_dialog_button_close, null)
+                                .create()
+                            retryDialog?.show()
+                        } else {
+                            // ENVOY_ENDED_UNKNOWN or other cause
+                            Log.w(TAG, "envoy failed, cause unclear")
+                        }
+                    }
                 } else {
                     Log.e(TAG, "received an unexpected intent: " + intent.action)
                 }
@@ -416,6 +450,12 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
         super.onResume()
 
         // start cronet here to prevent exception from starting a service when out of focus
+        checkAndInitEnvoy()
+
+        invalidateOptionsMenu()
+    }
+
+    private fun checkAndInitEnvoy() {
         if (Prefs.isInitialOnboardingEnabled) {
             // TODO: onCreate also checks the following before onboarding, is that necessary here?
             // savedInstanceState == null && !intent.hasExtra(Constants.INTENT_EXTRA_IMPORT_READING_LISTS
@@ -432,8 +472,6 @@ class MainActivity : SingleFragmentActivity<MainFragment>(), MainFragment.Callba
             waitingForEnvoy = true
             envoyInit()
         }
-
-        invalidateOptionsMenu()
     }
 
     override fun onStop() {

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -1301,4 +1301,13 @@
   <string name="reading_list_share_message_v2">Message that is sent to a recipient when sharing a reading list.</string>
   <string name="reading_list_share_survey_title">Title for dialog box that leads to a survey about sharing reading lists.</string>
   <string name="reading_list_share_survey_body">Message body for dialog box that leads to a survey about sharing reading lists.</string>
+
+  <string name="retry_dialog_title">Title for dialog box that prompts user to try to connect again with remaining options.</string>
+  <string name="retry_dialog_content">Message body for dialog box that prompts user to try to connect again with remaining options.</string>
+  <string name="retry_dialog_button_retry">Label for button to close dialog and try to connect again.</string>
+  <string name="retry_dialog_button_close">Label for button to close dialog without trying to connect again.</string>
+  <string name="failure_dialog_title">Title for dialog box that informs user that they cannot connect with any available option.</string>
+  <string name="failure_dialog_content">Message body for dialog box that informs user that they cannot connect with any available option.</string>
+  <string name="failure_dialog_button_close">Label for button to close dialog (no action can be taken).</string>
+
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1283,4 +1283,13 @@
   <string name="media_playback_error">播放媒體時出錯。</string>
   <string name="user_contrib_menu_label">貢獻</string>
   <string name="user_contrib_filter_activity_title">篩選貢獻</string>
+
+  <string name="retry_dialog_title">重试？</string>
+  <string name="retry_dialog_content">自由维基无法连接到网络, 但仍有备用方案。您是否愿意重试？</string>
+  <string name="retry_dialog_button_retry">确认</string>
+  <string name="retry_dialog_button_close">取消</string>
+  <string name="failure_dialog_title">连接失败</string>
+  <string name="failure_dialog_content">自由维基无法连接到网络, 所有备用方案也失败。请稍等一段时间再重试。</string>
+  <string name="failure_dialog_button_close">确认</string>
+
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1271,4 +1271,13 @@
   <string name="namespace_article">条目</string>
   <string name="user_contrib_current">当前</string>
   <string name="user_contrib_menu_label">贡献</string>
+
+  <string name="retry_dialog_title">重试？</string>
+  <string name="retry_dialog_content">自由维基无法连接到网络, 但仍有备用方案。您是否愿意重试？</string>
+  <string name="retry_dialog_button_retry">确认</string>
+  <string name="retry_dialog_button_close">取消</string>
+  <string name="failure_dialog_title">连接失败</string>
+  <string name="failure_dialog_content">自由维基无法连接到网络, 所有备用方案也失败。请稍等一段时间再重试。</string>
+  <string name="failure_dialog_button_close">确认</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1368,4 +1368,13 @@
     <string name="reading_list_share_survey_body">\"Share reading lists\" is a test feature and we need your feedback to improve or remove it.</string>
     <!-- /Shareable reading lists -->
 
+    <string name="retry_dialog_title">Retry</string>
+    <string name="retry_dialog_content">Envoy failed to start, but not all options were tested. Do you want to try again?</string>
+    <string name="retry_dialog_button_retry">OK</string>
+    <string name="retry_dialog_button_close">CANCEL</string>
+    <string name="failure_dialog_title">Blocked</string>
+    <string name="failure_dialog_content">Envoy failed to start and all options have been tested. You should wait a couple hours before trying again.</string>
+    <string name="failure_dialog_button_close">OK</string>
+
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1368,13 +1368,12 @@
     <string name="reading_list_share_survey_body">\"Share reading lists\" is a test feature and we need your feedback to improve or remove it.</string>
     <!-- /Shareable reading lists -->
 
-    <string name="retry_dialog_title">Retry</string>
-    <string name="retry_dialog_content">Envoy failed to start, but not all options were tested. Do you want to try again?</string>
+    <string name="retry_dialog_title">Retry?</string>
+    <string name="retry_dialog_content">Wiki Unblocked could not connect to the internet, but not all options were tested. Do you want to try again?</string>
     <string name="retry_dialog_button_retry">OK</string>
     <string name="retry_dialog_button_close">CANCEL</string>
     <string name="failure_dialog_title">Blocked</string>
-    <string name="failure_dialog_content">Envoy failed to start and all options have been tested. You should wait a couple hours before trying again.</string>
+    <string name="failure_dialog_content">Wiki Unblocked could not connect to the internet and all options were tested. You should wait several hours before trying again.</string>
     <string name="failure_dialog_button_close">OK</string>
-
 
 </resources>


### PR DESCRIPTION
since we've started having some issues with reliability, this dialog provides the user with a better idea of the status of the app and lets them retry without restarting the application.

![retry1](https://github.com/greatfire/apps-android-wikipedia-envoy/assets/6945405/0ca3cfe0-a89c-4a68-ac90-c4690f5b9f95)

![retry2](https://github.com/greatfire/apps-android-wikipedia-envoy/assets/6945405/ec38d66e-72f1-4d0c-8e6f-05b241d73543)

(this text will require translations)